### PR TITLE
Redis | Geocoding | geoRadiusByMember => This method is identical to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ $redis->geoAdd('Geocoding', -73.935242, 40.730610, 'New York');
 $redis->geoHash('Geocoding', 'San Francisco');
 $redis->geoPos('Geocoding', 'San Francisco');
 $redis->geoDist('Geocoding', 'San Francisco', 'New York');
-$redis->geoRadius("Geocoding", -157.858, 21.306, 300, 'mi', $options)
+$redis->geoRadius("Geocoding", -157.858, 21.306, 300, 'mi', $options);
+$redis->geoRadiusByMember("Geocoding", 'San Francisco', 300, 'mi', $options);
 ```
 
 ### [Hashes](docs/hashes.md)

--- a/docs/geocoding.md
+++ b/docs/geocoding.md
@@ -269,3 +269,41 @@ array(1) {
   }
 }
 ```
+
+## [geoRadiusByMember](https://redis.io/commands/geoRadiusByMember)
+
+_**Description**_: This method is identical to geoRadius except that instead of passing a longitude and latitude as the "source" you pass an existing member in the geospatial set.
+
+##### *Prototype*  
+
+```php
+public function geoRadiusByMember(
+    string $key,
+    string $member,
+    float $radius,
+    string $unit,
+    ?array $options = []
+): array {
+    return $this->redis->geoRadiusByMember($key, $member, $radius, $unit);
+}
+```
+
+##### *Parameters*
+
+- *key*: String. The GeoSpatial index.
+- *member*: String. Location name.
+- *radius*: Float. 
+- *unit*: String. Distance unit [m, km, mi, ft].
+- *options*: Array. _See bellow_
+
+##### *Return value*
+
+*float*: The distance between the two passed members in the units requested (meters by default).
+
+##### *Example*
+
+```php
+$redis->geoAdd('Geocoding', -122.431, 37.773, 'San Francisco');  // 1
+$redis->geoAdd('Geocoding', -121.893028, 37.335480, 'San Jose');  // 1
+$redis->geoRadiusByMember('Geocoding', 'San Francisco', 100, 'km'); // [0 => 'San Francisco', 1 => 'San Jose']
+```

--- a/src/Traits/Geocoding.php
+++ b/src/Traits/Geocoding.php
@@ -76,7 +76,8 @@ trait Geocoding
      * @param  string $unit      [description]
      * @param  array  $options   [description]
      *
-     * @return array            When no STORE option is passed, this function returns an array of results.
+     * @return array            When no STORE option is passed, this function
+     *                          returns an array of results.
      */
     public function geoRadius(
         string $key,
@@ -89,8 +90,26 @@ trait Geocoding
         return $this->redis->geoRadius($key, $longitude, $latitude, $radius, $unit);
     }
 
-    public function geoRadiusByMember(): bool
-    {
-        return false;
+    /**
+     * This method is identical to geoRadius except that instead of passing a
+     * longitude and latitude as the "source" you pass an existing member in
+     * the geospatial set.
+     *
+     * @param  string $key     [description]
+     * @param  string $member  [description]
+     * @param  float  $radius  [description]
+     * @param  string $unit    [description]
+     * @param  array  $options [description]
+     *
+     * @return array
+     */
+    public function geoRadiusByMember(
+        string $key,
+        string $member,
+        float $radius,
+        string $unit,
+        ?array $options = []
+    ): array {
+        return $this->redis->geoRadiusByMember($key, $member, $radius, $unit);
     }
 }

--- a/tests/RedisGeocodingTest.php
+++ b/tests/RedisGeocodingTest.php
@@ -113,4 +113,43 @@ class RedisGeocodingTest extends TestCase
         // Cleanup used keys
         $this->assertGreaterThanOrEqual(0, $this->redis->delete($this->key));
     }
+
+    /** @test */
+    public function redis_geocoding_georadiusbymember_single()
+    {
+        $california = [
+            0 => [
+                'longitude' => -121.478851,
+                'latitude' => 38.575764,
+                'location' => 'Sacramento',
+            ],
+            1 => [
+                'longitude' => -121.893028,
+                'latitude' => 37.335480,
+                'location' => 'San Jose',
+            ],
+            2 => [
+                'longitude' => -118.243683,
+                'latitude' => 34.052235,
+                'location' => 'Los Angeles',
+            ],
+        ];
+
+        // Start from scratch
+        $this->assertGreaterThanOrEqual(0, $this->redis->delete($this->key));
+        // Add San Francisco to the geospatial key should only do it once
+        $this->assertEquals(1, $this->redis->geoAdd($this->key, $this->longitude, $this->latitude, $this->location));
+
+        for ($i = 0; $i < count($california); $i++) {
+            $this->assertEquals(1, $this->redis->geoAdd($this->key, $california[$i]['longitude'], $california[$i]['latitude'], $california[$i]['location']));
+        }
+
+        $geoRadius = $this->redis->geoRadiusByMember($this->key, $this->location, 100, 'km');
+
+        $this->assertEquals('San Francisco', $geoRadius[0]);
+        $this->assertEquals('San Jose', $geoRadius[1]);
+
+        // Cleanup used keys
+        $this->assertGreaterThanOrEqual(0, $this->redis->delete($this->key));
+    }
 }


### PR DESCRIPTION
…geoRadius except that instead of passing a longitude and latitude as the "source" you pass an existing member in the geospatial set.